### PR TITLE
Add Colab notebook for PDF catalog chatbot

### DIFF
--- a/catalog_chatbot.ipynb
+++ b/catalog_chatbot.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ddc1b95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Mount my Google Drive. Then pip install pdfminer.six, sentence_transformers, faiss-cpu, transformers, bitsandbytes. Show only a '✅ Ready' print.\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive', force_remount=True)\n",
+    "!pip -q install pdfminer.six sentence_transformers faiss-cpu transformers bitsandbytes\n",
+    "print('✅ Ready')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60f24474",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Use google.colab.files.upload() so I can drop a catalog PDF of any name. Save the first uploaded file's path in CATALOG_PATH and print the filename.\n",
+    "from google.colab import files, output\n",
+    "uploaded = files.upload()\n",
+    "if not uploaded:\n",
+    "    raise ValueError('No file uploaded.')\n",
+    "CATALOG_PATH = next(iter(uploaded.keys()))\n",
+    "print(f\"📄 Catalog loaded: {CATALOG_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b443d8ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Read the PDF at CATALOG_PATH with pdfminer.high_level.extract_text. Split by the form-feed character '\f",
+    "' to keep page boundaries and store in list pages. Print 'Loaded X pages'.\n",
+    "from pdfminer.high_level import extract_text\n",
+    "raw_text = extract_text(CATALOG_PATH)\n",
+    "pages = raw_text.split('\f",
+    "')\n",
+    "print(f\"📑 Loaded {len(pages)} pages\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52f9c43f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Define make_chunks(pages, window=120, stride=80) that returns a list of dicts {text, page}. Use a sliding window of 'window' words every 'stride' words within each page. Then build the chunk list.\n",
+    "import re, json, math\n",
+    "def make_chunks(pages, window=120, stride=80):\n",
+    "    chunks = []\n",
+    "    for idx, pg in enumerate(pages, start=1):\n",
+    "        words = re.findall(r\"\\S+\", pg)\n",
+    "        for start in range(0, max(len(words)-window+1, 0), stride):\n",
+    "            segment = ' '.join(words[start:start+window])\n",
+    "            chunks.append({'text': segment, 'page': idx})\n",
+    "    return chunks\n",
+    "\n",
+    "chunks = make_chunks(pages)\n",
+    "print(f\"🧩 Created {len(chunks)} chunks (~{round(len(chunks)/len(pages),1)} per page)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "164aa644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Load sentence-transformers/all-mpnet-base-v2. Encode each chunk, L2-normalise, save embeddings to catalog_embeds.npy and chunks list to chunks.json. Print sizes.\n",
+    "import numpy as np, torch, json\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "model_emb = SentenceTransformer('sentence-transformers/all-mpnet-base-v2')\n",
+    "model_emb.max_seq_length = 512\n",
+    "\n",
+    "embeddings = model_emb.encode(\n",
+    "    [c['text'] for c in chunks],\n",
+    "    convert_to_numpy=True,\n",
+    "    show_progress_bar=True,\n",
+    "    normalize_embeddings=True,\n",
+    ").astype('float32')\n",
+    "\n",
+    "np.save('/content/drive/MyDrive/catalog_embeds.npy', embeddings)\n",
+    "with open('/content/drive/MyDrive/chunks.json', 'w') as f:\n",
+    "    json.dump(chunks, f)\n",
+    "\n",
+    "print(f\"🔒 Saved {embeddings.shape[0]} embeddings → catalog_embeds.npy ({embeddings.nbytes/1e6:.1f} MB)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de962496",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: If catalog.index exists in Drive, load it; else create a faiss.IndexFlatIP, add the embeddings, and write it to catalog.index. Print 'Index ready (N vectors)'.\n",
+    "import faiss, os\n",
+    "index_path = '/content/drive/MyDrive/catalog.index'\n",
+    "if os.path.exists(index_path):\n",
+    "    index = faiss.read_index(index_path)\n",
+    "else:\n",
+    "    index = faiss.IndexFlatIP(embeddings.shape[1])\n",
+    "    index.add(embeddings)\n",
+    "    faiss.write_index(index, index_path)\n",
+    "print(f\"⚡ Index ready ({index.ntotal} vectors)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8499b18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Load 4-bit-quantized microsoft/phi-2 with bitsandbytes (device_map='auto'). Build a text-generation pipeline 'generate' with temperature 0.2, max_new_tokens 300. Print device.\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline\n",
+    "tokenizer = AutoTokenizer.from_pretrained('microsoft/phi-2')\n",
+    "model_llm = AutoModelForCausalLM.from_pretrained(\n",
+    "    'microsoft/phi-2',\n",
+    "    device_map='auto',\n",
+    "    load_in_4bit=True,\n",
+    "    trust_remote_code=True,\n",
+    ")\n",
+    "generate = pipeline(\n",
+    "    'text-generation',\n",
+    "    model=model_llm,\n",
+    "    tokenizer=tokenizer,\n",
+    "    temperature=0.2,\n",
+    "    max_new_tokens=300,\n",
+    "    repetition_penalty=1.1,\n",
+    ")\n",
+    "device = next(model_llm.parameters()).device\n",
+    "print(f\"🤖 LLM loaded on {device}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51676ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Implement ask(q, k=7): embed q, search FAISS, build prompt with retrieved chunks (showing page numbers), and answer with generate(). If max similarity < 0.25, reply: 'Συγγνώμη 🙏 – ρώτα με κάτι που υπάρχει στον πανεπιστημιακό κατάλογο! (Sorry – please ask something from the university catalog!)'.  Include course codes, titles, credits exactly as in context, and cite pages as '(see p. 123)'.\n",
+    "def ask(question, k=7, min_sim=0.25):\n",
+    "    # 1. embed question\n",
+    "    q_vec = model_emb.encode(question, convert_to_numpy=True, normalize_embeddings=True).astype('float32')\n",
+    "    # 2. search FAISS\n",
+    "    D, I = index.search(q_vec.reshape(1, -1), k)\n",
+    "    top_scores = D[0]\n",
+    "    top_ids = I[0]\n",
+    "    if top_scores[0] < min_sim:\n",
+    "        return 'Συγγνώμη 🙏 – ρώτα με κάτι που υπάρχει στον πανεπιστημιακό κατάλογο!\n",
+    "Sorry 🙏 – please ask something from the university catalog!'\n",
+    "    # 3. build context with page refs\n",
+    "    ctx_parts = []\n",
+    "    for score, idx in zip(top_scores, top_ids):\n",
+    "        chunk = chunks[int(idx)]\n",
+    "        ctx_parts.append(f\"[p.{chunk['page']}] {chunk['text']}\")\n",
+    "    context = '\n",
+    "'.join(ctx_parts)\n",
+    "    # 4. compose prompt\n",
+    "    prompt = (\n",
+    "        'You are UniCatalogBot. Answer ONLY with information found in the CONTEXT. '\n",
+    "        'List course codes, titles, credits & descriptions verbatim when relevant. '\n",
+    "        'Cite page numbers like (see p. 123). If answer not in context, apologise in Greek & English.\n",
+    "\n",
+    "'\n",
+    "        f'CONTEXT:\n",
+    "{context}\n",
+    "\n",
+    "'\n",
+    "        f'QUESTION: {question}\n",
+    "\n",
+    "ANSWER:'\n",
+    "    )\n",
+    "    # 5. generate\n",
+    "    result = generate(prompt)[0]['generated_text']\n",
+    "    # 6. strip the prompt part from the output (keep text after 'ANSWER:')\n",
+    "    answer_start = result.find('ANSWER:')\n",
+    "    answer = result[answer_start + len('ANSWER:'):].strip() if answer_start != -1 else result\n",
+    "    return answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cb3ba13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Run ask('I am a Computer Science major. What required and elective courses do I need?') and print the answer.\n",
+    "print(ask('I am a Computer Science major. What required and elective courses do I need?'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d02eb6bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Prompt I used: Create a simple loop: while True ask for input('📚> '); break on 'quit' or empty; else print ask().\n",
+    "while True:\n",
+    "    try:\n",
+    "        user_q = input('📚> ').strip()\n",
+    "    except EOFError:\n",
+    "        break\n",
+    "    if user_q.lower() in {'quit', ''}:\n",
+    "        print('👋 Bye!')\n",
+    "        break\n",
+    "    print(ask(user_q))"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `catalog_chatbot.ipynb` demonstrating how to build a catalog chatbot in Colab

## Testing
- `jq '.cells|length' catalog_chatbot.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_683f77c56008832ca8681f8d1220a0de